### PR TITLE
Fix for Filtering Modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ In your components:
   }
 }
 ```
+Available Modules:
+- bold
+- headings
+- hyperlink
+- image
+- italic
+- list_ordered
+- list_unordered
+- removeFormat
+- table
+
 Note on the image upload API endpoint:
 - Image is uploaded by `multipart/form-data`
 - Your endpoint must respond back with a string, the URL for the image - e.g. `http://myapp.com/images/12345.jpg`

--- a/src/Editr.vue
+++ b/src/Editr.vue
@@ -72,7 +72,7 @@ export default {
     computed: {
         modules: function() {
             if (bus.options.hideModules)
-                return modules.filter(m => !bus.options.hideModules[m.name]);
+                return modules.filter(m => !bus.options.hideModules.includes(m.name));
             return modules;
         },
 


### PR DESCRIPTION
Adding items to the `hideModules` prop in the bus options was not correctly filtering out the unwanted modules. This fix handles that.