### PR TITLE
Add button type="button"

### DIFF
--- a/src/modules/headings.vue
+++ b/src/modules/headings.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <button @click="insertHeading">H1</button>
-        <button @click="insertHeading">H2</button>
-        <button @click="insertHeading">H3</button>
+        <button type="button" @click="insertHeading">H1</button>
+        <button type="button" @click="insertHeading">H2</button>
+        <button type="button" @click="insertHeading">H3</button>
     </div>
 </template>
 


### PR DESCRIPTION
If the editor is wrapped in a `<form>` element, by default it will submit if there isn't a defined type or cancellation of the default event. Realistically using buttons here isn't a great choice, but if you must use them setting the type is important. There are 2 other instances of buttons with submit types, you might want to consider making these actions happen dynamically onClick.