### PR TITLE
fixed leftover selections lingering in some browsers after new styles applied

### DIFF
--- a/src/Editr.vue
+++ b/src/Editr.vue
@@ -127,11 +127,27 @@ export default {
                     range.select();
             }
         },
-
+        clearSelection() {
+          this.selection = null;
+          const selection = null;
+          if (window.getSelection) {
+            selection = window.getSelection();
+          } else if (document.selection) {
+            selection = document.selection;
+          }
+          if (selection) {
+            if (selection.empty) {
+              selection.empty();
+            }
+            if (selection.removeAllRanges) {
+              selection.removeAllRanges();
+            }
+          }
+        },
         exec (cmd, arg, sel){
             sel !== false && this.selection && this.restoreSelection(this.selection);
             document.execCommand(cmd, false, arg||"");
-            this.selection = null;
+            this.clearSelection();
 
             this.$nextTick(this.emit);
         },


### PR DESCRIPTION
I was having a weird issue where in some browsers (Chrome and Firefox, but not Safari), the selection that a style would be applied for would linger such that any subsequent style applications would occur to that original selection and not others. This would basically lead to behavior where you could only style your single first selection of text, and nothing else.

Curiously, I could not reproduce this behavior in the demo site for this repo, so I imagine something is conflicting in my setup that brought about this bug. Whatever the case, explicitly clearing the browser's selection along with the locally stored `selection` fixed the issue for me.