### PR TITLE
added ability to override icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ All keys are optional.
   // { [module]: boolean (set true to hide) }
   hideModules: { "bold": true },
 
+  // you can override icons too, if desired
+  // just keep in mind that you may need custom styles in your application to get everything to align
+  iconOverrides: { "bold": "<i class="your-custom-icon"></i>" },
+
   // if the image option is not set, images are inserted as base64
   image: {
     uploadURL: "/api/myEndpoint",

--- a/src/editor/Editr.vue
+++ b/src/editor/Editr.vue
@@ -84,10 +84,19 @@ export default {
         },
 
         modules: function() {
-            return modules.filter(
+            const filteredModules = modules.filter(
                 m => this.mergedOptions.hideModules === undefined
                 || !this.mergedOptions.hideModules[m.title]
             ).concat(this.mergedOptions.customModules);
+
+            const filteredModulesWithIcons = filteredModules.map((filteredModule) => {
+              const iconOverrides = this.mergedOptions.iconOverrides
+              if (iconOverrides && iconOverrides[filteredModule.title]) {
+                filteredModule.icon = iconOverrides[filteredModule.title]
+              }
+              return filteredModule
+            })
+            return filteredModulesWithIcons
         },
 
         btnsWithDashboards: function () {


### PR DESCRIPTION
another contribution from me. hopefully, this one is more foolproof

code standards have been difficult for me to follow given that there's no linters or code formatters configured, but i did the best i can. also, it doesn't look like the `.editorconfig` is actually being consumed given that i see variations of indentation throughout the files?

additionally, it would be useful if the `src` itself was bundled in the npm artifact, as you can consume that directly in other webpack projects. for contributors, you can alias or symlink the dependency to wherever the forked repo exists on disk to allow for seamless manual verification. it also just allows for a common entrypoint when checking out from git while waiting for the upstream to accept the changes