### PR TITLE
[#66] adding support for 'dropzone-sending' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ All keys are optional.
   // if the image option is not set, images are inserted as base64
   image: {
     uploadURL: "/api/myEndpoint",
+    requestParams: {
+      p1: 'I will be added to the request'
+    },
     dropzoneOptions: {}
   },
 

--- a/src/editor/modules/image.vue
+++ b/src/editor/modules/image.vue
@@ -5,6 +5,7 @@
         ref="dropzone"
         @vdropzone-success="fileUploaded"
         @vdropzone-file-added="fileAdded"
+        @vdropzone-sending="sendingEvent"
         >
     </Dropzone>
 </template>
@@ -34,7 +35,7 @@ export default {
         dropzoneOptions () {
           return {
             // custom dropzone options
-            ...this.options.image.dropzoneOptions,
+            options: this.options.image.dropzoneOptions,
 
             // vue2-dropzone config
             id: `${this._uid}vwdropzone`,
@@ -64,6 +65,15 @@ export default {
             }, false);
 
             reader.readAsDataURL(file);
+        },
+
+        sendingEvent (f, r, formData) {
+          if (this.uploadURL === "None" || !this.options.image.requestParams)
+            return;
+
+          Object.keys(this.options.image.requestParams).forEach(key => {
+            formData.append(key, this.options.image.requestParams[key]);
+          });
         }
     },
 }


### PR DESCRIPTION
This will make it possible to add any additional parameters to the request when an image is uploaded via an API.