### PR TITLE
added the option to force a conversion to plain text on paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ All keys are optional.
   },
 
   // limit content height if you wish. If not set, editor size will grow with content.
-  maxHeight: "500px"
+  maxHeight: "500px",
+
+  // set to 'true' this will insert plain text without styling when you paste something into the editor.
+  forcePlainTextOnPaste: true
 }
 ```
 Available Modules:

--- a/src/editor/Editr.vue
+++ b/src/editor/Editr.vue
@@ -190,6 +190,16 @@ export default {
           this.selection = this.saveSelection();
         },
 
+        onPaste(e) {
+            e.preventDefault();
+
+             // get a plain representation of the clipboard
+            var text = e.clipboardData.getData("text/plain");
+
+            // insert that plain text text manually
+            document.execCommand("insertHTML", false, text);
+        },
+
         syncHTML () {
             if (this.html !== this.$refs.content.innerHTML)
                 this.innerHTML = this.html;
@@ -204,6 +214,11 @@ export default {
         this.$refs.content.addEventListener("focus", this.onFocus);
         this.$refs.content.addEventListener("input", this.onInput);
         this.$refs.content.addEventListener("blur", this.onContentBlur, { capture: true });
+
+        if (this.mergedOptions.forcePlainTextOnPaste === true) {
+            this.$refs.content.addEventListener("paste", this.onPaste);
+        }
+        
         this.$refs.content.style.maxHeight = this.mergedOptions.maxHeight;
     },
 


### PR DESCRIPTION
I've added the ability to enable a conversion to plain text when you paste text into the editor.
This is useful if you like to stick to a specific styling in your application.
Also you're not able to remove most of the styling once pasted into the editor.