### PR TITLE
Add emit on Blur event on editor.

### DIFF
--- a/src/editor/Editr.vue
+++ b/src/editor/Editr.vue
@@ -188,6 +188,7 @@ export default {
         onContentBlur () {
           // save focus to restore it later
           this.selection = this.saveSelection();
+          this.$emit("blur", this.$refs.content);
         },
 
         onPaste(e) {


### PR DESCRIPTION
In IE Quill editor can't bind v-model.
So, I need blur event.
Add emit on Blur event on editor.
Thank you,