### PR TITLE
Publish source along with the rest of the package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 *
 !dist/vueWysiwyg.js
 !dist/vueWysiwyg.css
+!src


### PR DESCRIPTION
It's standard practice to publish the source along with the rest of the package.

That way, devs can use the bundler (and css prefixer) of their choice, and in case of shared dependencies (like debounce), avoid the duplicate code.